### PR TITLE
Add FastAPI ECS deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ In this project, I ensure to:
 2. Adjust my Sagemaker notebooks to perform training and deployment on EC2.
 3. Set up a Lambda function for my deployed model. Set up auto-scaling for my deployed endpoint as well as concurrency for my Lambda function.
 4. Ensure that the security on my ML pipeline is set up properly.
+
+## FastAPI Service Deployment on ECS
+
+See [fastapi_service/README.md](fastapi_service/README.md) for instructions on containerizing the model inference API with FastAPI and deploying it to Amazon ECS with auto-scaling.

--- a/fastapi_service/Dockerfile
+++ b/fastapi_service/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.9-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py ./
+EXPOSE 8080
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/fastapi_service/README.md
+++ b/fastapi_service/README.md
@@ -1,0 +1,68 @@
+# FastAPI Model Service on ECS
+
+This folder contains a minimal FastAPI application that serves the dog breed classifier model. The service expects a PyTorch model file named `model.pth` to be available inside the container. You can mount or copy the model when building the image.
+
+## Building the Docker image
+
+```bash
+# copy your trained model into this directory
+docker build -t dog-classifier-fastapi .
+```
+
+## Pushing to Amazon ECR
+
+```bash
+aws ecr create-repository --repository-name dog-classifier-fastapi
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION=us-east-1
+aws ecr get-login-password --region $REGION | \
+  docker login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+
+docker tag dog-classifier-fastapi:latest $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/dog-classifier-fastapi:latest
+docker push $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/dog-classifier-fastapi:latest
+```
+
+## Deploying on ECS with Auto Scaling
+
+The example below creates a Fargate service with an application load balancer and configures target tracking scaling based on CPU utilization.
+
+```bash
+# Create a cluster
+aws ecs create-cluster --cluster-name dog-classifier-cluster
+
+# Register the task definition
+aws ecs register-task-definition \
+  --family dog-classifier-task \
+  --requires-compatibilities FARGATE \
+  --network-mode awsvpc \
+  --cpu "512" --memory "1024" \
+  --execution-role-arn <ecsTaskExecutionRoleArn> \
+  --container-definitions file://container_definitions.json
+
+# Create service with an application load balancer
+aws ecs create-service \
+  --cluster dog-classifier-cluster \
+  --service-name dog-classifier-service \
+  --task-definition dog-classifier-task \
+  --desired-count 1 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-xxxx],securityGroups=[sg-xxxx],assignPublicIp=ENABLED}" \
+  --load-balancers "targetGroupArn=arn:aws:elasticloadbalancing:...:targetgroup/...,containerName=dog-classifier,containerPort=8080"
+
+# Configure auto scaling
+aws application-autoscaling register-scalable-target \
+  --service-namespace ecs \
+  --resource-id service/dog-classifier-cluster/dog-classifier-service \
+  --scalable-dimension ecs:service:DesiredCount \
+  --min-capacity 1 --max-capacity 4
+
+aws application-autoscaling put-scaling-policy \
+  --service-namespace ecs \
+  --resource-id service/dog-classifier-cluster/dog-classifier-service \
+  --scalable-dimension ecs:service:DesiredCount \
+  --policy-name cpu-target-tracking \
+  --policy-type TargetTrackingScaling \
+  --target-tracking-scaling-policy-configuration '{"TargetValue":50.0,"PredefinedMetricSpecification":{"PredefinedMetricType":"ECSServiceAverageCPUUtilization"}}'
+```
+
+These commands assume that networking resources such as VPC, subnets, and security groups already exist. Update the placeholders with your specific resource identifiers.

--- a/fastapi_service/container_definitions.json
+++ b/fastapi_service/container_definitions.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "dog-classifier",
+    "image": "<account>.dkr.ecr.<region>.amazonaws.com/dog-classifier-fastapi:latest",
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "protocol": "tcp"
+      }
+    ],
+    "environment": [
+      {"name": "MODEL_PATH", "value": "/app/model.pth"}
+    ]
+  }
+]

--- a/fastapi_service/main.py
+++ b/fastapi_service/main.py
@@ -1,0 +1,44 @@
+import os
+import io
+from fastapi import FastAPI, UploadFile, File
+from PIL import Image
+import torch
+import torch.nn as nn
+import torchvision.models as models
+import torchvision.transforms as transforms
+
+app = FastAPI()
+
+def Net():
+    model = models.resnet50(pretrained=False)
+    for param in model.parameters():
+        param.requires_grad = False
+    model.fc = nn.Sequential(
+        nn.Linear(2048, 128),
+        nn.ReLU(inplace=True),
+        nn.Linear(128, 133)
+    )
+    return model
+
+MODEL_PATH = os.environ.get("MODEL_PATH", "model.pth")
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+model = Net().to(device)
+if os.path.exists(MODEL_PATH):
+    model.load_state_dict(torch.load(MODEL_PATH, map_location=device))
+model.eval()
+
+transform = transforms.Compose([
+    transforms.Resize((224, 224)),
+    transforms.ToTensor(),
+])
+
+@app.post("/predict")
+async def predict(file: UploadFile = File(...)):
+    image_bytes = await file.read()
+    img = Image.open(io.BytesIO(image_bytes))
+    input_tensor = transform(img).unsqueeze(0).to(device)
+    with torch.no_grad():
+        outputs = model(input_tensor)
+        _, predicted = torch.max(outputs, 1)
+    return {"prediction": predicted.item()}

--- a/fastapi_service/requirements.txt
+++ b/fastapi_service/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+torch
+torchvision
+Pillow


### PR DESCRIPTION
## Summary
- implement FastAPI inference service
- add Dockerfile and container definition
- document how to push to ECR and deploy on ECS with auto scaling
- link instructions from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db65710b4832392510ab35a3952ab